### PR TITLE
Fix white space on the right as best possible

### DIFF
--- a/dot_config/alacritty/alacritty.yml.tmpl
+++ b/dot_config/alacritty/alacritty.yml.tmpl
@@ -12,7 +12,7 @@ env:
   # available, otherwise `xterm-256color` is used.
   TERM: xterm-256color
 
-#window:
+window:
   # Window dimensions (changes require restart)
   #
   # Specified in number of columns/lines, not pixels.
@@ -38,7 +38,7 @@ env:
   #  y: 0
 
   # Spread additional padding evenly around the terminal content.
-  #dynamic_padding: false
+  dynamic_padding: true
 
   # Window decorations
   #
@@ -49,7 +49,7 @@ env:
   # Values for `decorations` (macOS only):
   #     - transparent: Title bar, transparent background and title bar buttons
   #     - buttonless: Title bar, transparent background, but no title bar buttons
-  #decorations: full
+  decorations: none
 
   # Startup Mode (changes require restart)
   #


### PR DESCRIPTION
There is a white space on the right. It seems like a missing scrollbar
but there is no option for that. So to fix it, adjust the scaling.